### PR TITLE
fix: mobile scrolling on end game stats screen (reported by E5Burrito)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1871,12 +1871,13 @@ button:hover, button:disabled {
     margin: auto;
     text-align: center;
     color: #00ff00;
-    padding: 40px;
+    padding: 20px 20px; /* Adjusted padding for mobile */
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 30px;
     font-family: monospace;
+    min-height: 100%; /* Ensure content fills the screen */
 }
 
 .glowing-potato {
@@ -2817,5 +2818,40 @@ body:not(.animations-disabled) .potato .growth-indicator {
     .help-section.highlight,
     .help-subsection.highlight {
         animation: highlight-section-dark 2s ease-out;
+    }
+}
+
+/* Mobile adjustments for final stats */
+@media screen and (max-width: 768px) {
+    .singularity-screen {
+        position: fixed;
+        height: 100%;
+        overflow-y: scroll;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .singularity-content {
+        padding: 20px;
+        margin: 0 auto;
+        width: 90%;
+        gap: 0px;
+    }
+
+    .final-stats {
+        margin: 10px 0;
+        padding: 15px;
+    }
+
+    .final-buttons {
+        flex-direction: column;
+        width: 100%;
+        gap: 10px;
+        padding-bottom: 30px; /* Add padding at bottom for better scrolling */
+    }
+
+    .final-button {
+        width: 100%;
+        padding: 15px;
+        margin: 5px 0;
     }
 }

--- a/todo.md
+++ b/todo.md
@@ -113,6 +113,7 @@ TODO:
     - [x] Update settings saved success message
     - [x] Center settings modal on desktop
     - [x] Fix modal background color (broken in 4bfc788)
+- [x] Create instructions for how to play
 --------------------------------------------------------------------------------------------
 - [ ] Implement automation panel
     - [ ] Resource consumption + production rates per machine
@@ -126,7 +127,6 @@ TODO:
     - [ ] Improve upgrade descriptions
 - [ ] Balance upgrade costs and effects
 - [ ] Implement nuclear meltdown if too much ice is melted too quickly
-- [ ] Create instructions for how to play
 - [ ] Write a README.md for the project
 
 


### PR DESCRIPTION
Bug reported by E5Burrito where the final statistics screen was not scrollable 
on mobile browsers (specifically DuckDuckGo). Added proper overflow handling 
and mobile-specific styles to ensure the end game screen is fully scrollable 
and accessible on all mobile devices.

Changes:
- Added overflow-y: auto and -webkit-overflow-scrolling: touch
- Improved mobile layout with responsive widths and proper padding
- Made buttons stack vertically on mobile for better usability
- Fixed potential horizontal scroll issues